### PR TITLE
👷 add dust check

### DIFF
--- a/src/Market.sol
+++ b/src/Market.sol
@@ -580,9 +580,11 @@ contract Market {
 
         // update bid order remaining quantity
         bid.remaining = remainingNumeraire;
-
         // update bid order status
-        bid.status = (remainingNumeraire == 0)
+        /// @dev Rather than only checking if bid.remaining is zero,
+        /// this checks if the remaining numeraire is dust
+        /// in which case the order is considered FILLED
+        bid.status = ((bid.remaining / limitPrice) == 0)
             ? STATUS.FILLED
             : (remainingNumeraire < trade_.quantity) ? STATUS.PARTIAL : STATUS.OPEN;
 
@@ -689,8 +691,12 @@ contract Market {
                     bid.remaining -= numeraireToReceive;
 
                     // update bid order status
-                    bid.status =
-                        (bid.remaining == 0) ? STATUS.FILLED : STATUS.PARTIAL;
+                    /// @dev Rather than only checking if bid.remaining is zero,
+                    /// this checks if the remaining numeraire is dust
+                    /// in which case the order is considered FILLED
+                    bid.status = ((bid.remaining / bidPrice) == 0)
+                        ? STATUS.FILLED
+                        : STATUS.PARTIAL;
 
                     /// @custom:settle
                     index.transfer(bid.trader, remainingIndex);
@@ -1000,8 +1006,12 @@ contract Market {
                 bid.remaining -= numeraireToReceive;
 
                 // update bid order status
-                bid.status =
-                    (bid.remaining == 0) ? STATUS.FILLED : STATUS.PARTIAL;
+                /// @dev Rather than only checking if bid.remaining is zero,
+                /// this checks if the remaining numeraire is dust
+                /// in which case the order is considered FILLED
+                bid.status = ((bid.remaining / price) == 0)
+                    ? STATUS.FILLED
+                    : STATUS.PARTIAL;
 
                 // reduce bid depth of current price level
                 level.bidDepth -= numeraireToReceive;

--- a/src/Market.sol
+++ b/src/Market.sol
@@ -698,6 +698,11 @@ contract Market {
                         ? STATUS.FILLED
                         : STATUS.PARTIAL;
 
+                    // remove potential dust from level depth
+                    if (bid.status == STATUS.FILLED && bid.remaining > 0) {
+                        level.bidDepth -= bid.remaining;
+                    }
+
                     /// @custom:settle
                     index.transfer(bid.trader, remainingIndex);
 
@@ -715,7 +720,7 @@ contract Market {
                     numeraireReceived += numeraireToReceive;
 
                     // reduce bid depth of current price level
-                    level.bidDepth -= numeraireToReceive;
+                    level.bidDepth -= bid.remaining;
 
                     // update bid order remaining quantity to 0
                     bid.remaining = 0;
@@ -1002,6 +1007,9 @@ contract Market {
                 remainingIndex -= indexToFill;
                 numeraireReceived += numeraireToReceive;
 
+                // reduce bid depth of current price level
+                level.bidDepth -= numeraireToReceive;
+
                 // update bid order remaining quantity
                 bid.remaining -= numeraireToReceive;
 
@@ -1013,8 +1021,10 @@ contract Market {
                     ? STATUS.FILLED
                     : STATUS.PARTIAL;
 
-                // reduce bid depth of current price level
-                level.bidDepth -= numeraireToReceive;
+                // remove potential dust from level depth
+                if (bid.status == STATUS.FILLED && bid.remaining > 0) {
+                    level.bidDepth -= bid.remaining;
+                }
 
                 /// @custom:settle
                 index.transfer(bid.trader, indexToFill);


### PR DESCRIPTION
This PR introduces logic to proactively mark orders as `FILLED` when their remaining amount becomes unmatchable due to indivisible rounding — commonly referred to as **"dust"**. This applies specifically to **bids**, where the remaining numeraire (e.g. sUSD) is insufficient to purchase even 1 wei of the index asset at a given price level.

For a `sBTC/sUSD` Market, at a price level of `100.000$`, a bid of less than `0.0000000000001` sUSD would be considered dust as it cannot buy 1 wei of BTC. Amount is negligible which is why we choose not refund dust to increase book performance.

Dust is left on the contract (TBD what to do with it).

## Description
During Limit Bid Placement (`__placeBid`)
- After matching against asks, we check if the remaining amount is dust (`(bid.remaining / price == 0)`) where we previously only checked if (`(bid.remaining == 0)`)
- If so, mark the bid as `FILLED` (instead of `PARTIAL` previously for those dust orders) and don’t enqueue


During Ask Matching Against Bids (`__placeAsk` and `__placeMarketAsk`)
- After filling part of a bid, we check if its remaining amount is now dust
- If so, we mark it as FILLED and dequeue it

## Motivation and Context
By marking these dust orders as `FILLED` (they can never be matched), we prevent accumulation of unfillable orders and keep the order book clean and deterministic.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

-   [x] Ran `make test`?
-   [x] Ran `make lint`?
